### PR TITLE
GVC API update

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -62,16 +62,18 @@ tags:
     description: |
       <SchemaDefinition schemaRef="#/components/schemas/TransactionsRequest" showReadOnly={true} showWriteOnly={true} />
 x-tagGroups:
-  - name: General
+  - name: Internal
     tags:
       - Voter (1.0.0)
       - Delegation (1.0.0)
-      - Drep (1.0.0)
       - Social (1.0.0)
       - Tag (1.0.0)
       - Privacy policy (1.0.0)
       - Terms and conditions (1.0.0)
       - Transactions (1.0.0)
+  - name: Public
+    tags:
+      - Drep (1.0.0)
   - name: Models
     tags:
       - voter_model
@@ -220,9 +222,7 @@ components:
                           type: boolean
                         is_approved:
                           type: boolean
-                        is_public_drep:
-                          type: boolean
-                       
+
                         drep_tags:
                           type: object
                           properties:
@@ -414,8 +414,6 @@ components:
                         hide_email:
                           type: boolean
                         is_approved:
-                          type: boolean
-                        is_public_drep:
                           type: boolean
                         drep_tags:
                           type: object
@@ -636,8 +634,6 @@ components:
                           type: boolean
                         is_approved:
                           type: boolean
-                        is_public_drep:
-                          type: boolean
                         drep_tags:
                           type: object
                           properties:
@@ -833,8 +829,6 @@ components:
                           type: boolean
                         is_approved:
                           type: boolean
-                        is_public_drep:
-                          type: boolean
                         drep_tags:
                           type: object
                           properties:
@@ -983,7 +977,6 @@ components:
             - email
             - hide_email
             - is_approved
-            - is_public_drep
           type: object
           properties:
             public_voting_key:
@@ -1039,9 +1032,6 @@ components:
             is_approved:
               type: boolean
               description: "Is drep approved?"
-            is_public_drep:
-              type: boolean
-              description: "Is drep public?"
             drep_tags:
               type: array
               items:
@@ -1094,8 +1084,6 @@ components:
             hide_email:
               type: boolean
             is_approved:
-              type: boolean
-            is_public_drep:
               type: boolean
             drep_tags:
               type: object
@@ -1161,8 +1149,6 @@ components:
             hide_email:
               type: boolean
             is_approved:
-              type: boolean
-            is_public_drep:
               type: boolean
             drep_tags:
               type: object
@@ -1257,8 +1243,6 @@ components:
               type: boolean
             is_approved:
               type: boolean
-            is_public_drep:
-              type: boolean
             drep_tags:
               type: object
               properties:
@@ -1323,8 +1307,6 @@ components:
             hide_email:
               type: boolean
             is_approved:
-              type: boolean
-            is_public_drep:
               type: boolean
             drep_tags:
               type: object
@@ -1405,8 +1387,6 @@ components:
                         hide_email:
                           type: boolean
                         is_approved:
-                          type: boolean
-                        is_public_drep:
                           type: boolean
                         drep_tags:
                           type: object
@@ -1592,8 +1572,6 @@ components:
                         hide_email:
                           type: boolean
                         is_approved:
-                          type: boolean
-                        is_public_drep:
                           type: boolean
                         drep_tags:
                           type: object
@@ -1801,8 +1779,6 @@ components:
                           type: boolean
                         is_approved:
                           type: boolean
-                        is_public_drep:
-                          type: boolean
                         drep_tags:
                           type: object
                           properties:
@@ -1987,8 +1963,6 @@ components:
                         hide_email:
                           type: boolean
                         is_approved:
-                          type: boolean
-                        is_public_drep:
                           type: boolean
                         drep_tags:
                           type: object
@@ -2205,8 +2179,6 @@ components:
                           type: boolean
                         is_approved:
                           type: boolean
-                        is_public_drep:
-                          type: boolean
                         drep_tags:
                           type: object
                           properties:
@@ -2379,8 +2351,6 @@ components:
                         hide_email:
                           type: boolean
                         is_approved:
-                          type: boolean
-                        is_public_drep:
                           type: boolean
                         drep_tags:
                           type: object
@@ -2576,8 +2546,6 @@ components:
                           type: boolean
                         is_approved:
                           type: boolean
-                        is_public_drep:
-                          type: boolean
                         drep_tags:
                           type: object
                           properties:
@@ -2750,8 +2718,6 @@ components:
                         hide_email:
                           type: boolean
                         is_approved:
-                          type: boolean
-                        is_public_drep:
                           type: boolean
                         drep_tags:
                           type: object
@@ -2949,8 +2915,6 @@ components:
                           type: boolean
                         is_approved:
                           type: boolean
-                        is_public_drep:
-                          type: boolean
                         drep_tags:
                           type: object
                           properties:
@@ -3121,8 +3085,6 @@ components:
                         hide_email:
                           type: boolean
                         is_approved:
-                          type: boolean
-                        is_public_drep:
                           type: boolean
                         drep_tags:
                           type: object
@@ -3316,8 +3278,6 @@ components:
                           type: boolean
                         is_approved:
                           type: boolean
-                        is_public_drep:
-                          type: boolean
                         drep_tags:
                           type: object
                           properties:
@@ -3488,8 +3448,6 @@ components:
                         hide_email:
                           type: boolean
                         is_approved:
-                          type: boolean
-                        is_public_drep:
                           type: boolean
                         drep_tags:
                           type: object
@@ -3691,8 +3649,6 @@ components:
                           type: boolean
                         is_approved:
                           type: boolean
-                        is_public_drep:
-                          type: boolean
                         drep_tags:
                           type: object
                           properties:
@@ -3877,8 +3833,6 @@ components:
                         hide_email:
                           type: boolean
                         is_approved:
-                          type: boolean
-                        is_public_drep:
                           type: boolean
                         drep_tags:
                           type: object
@@ -4086,8 +4040,6 @@ components:
                           type: boolean
                         is_approved:
                           type: boolean
-                        is_public_drep:
-                          type: boolean
                         drep_tags:
                           type: object
                           properties:
@@ -4272,8 +4224,6 @@ components:
                         hide_email:
                           type: boolean
                         is_approved:
-                          type: boolean
-                        is_public_drep:
                           type: boolean
                         drep_tags:
                           type: object


### PR DESCRIPTION
Endpoints are split into Internal and External endpoints and is_public_drep is removed from drep